### PR TITLE
fix BOOL is int error in Paint msg, start 64 bit fix

### DIFF
--- a/euphoria/include/redylib_0_9/oswin/win32/win32const.e
+++ b/euphoria/include/redylib_0_9/oswin/win32/win32const.e
@@ -29,14 +29,32 @@ include std/math.e
 include std/error.e
 
 
-public constant
+ifdef NO_CHANDLE then  --eu4 and older eu41 beta doesn't have this
+   include std\win32\w32dllconst.ew
+end ifdef
+
+--this should be in win32dll too
+ifdef EU4_0 then
+	define BITS32
+end ifdef
+
+
+ifdef BITS32 then
+	constant szLpsz = 4
+elsedef
+	constant szLpsz = 8
+end ifdef
+
+public constant  --needs 32/64 switches
 szByte = 1,
 szWord = 2,
-szLong = 4,
+szLong = 4,     --may not be 4 on linux64?
 szDWord = 4,
-szLpsz = 4,
 szUInt = 4,
+szBOOL = 4,
 szShort = 2,
+
+
 SIZEOF_BITMAP = szLong + szLong + szLong + szLong + szWord + szWord + szLpsz
 /*typedef struct tagBITMAP {
     LONG   bmType;


### PR DESCRIPTION
using the github web client to edit win32.e and win32onst.e not much fun
the commit and pull request should have included both files.
let me know if it didn't I will try again.
started a fix for 64bit
lifted the struct out of the Paint msg loop
fixed the errors in the offset for RECT in the Paint msg
fixed using szByte instead of szBOOL in the allocation
